### PR TITLE
Add Cloud Agent dev environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,15 @@
+{
+  "name": "GitPress.net",
+  "install": "./.cursor/install.sh",
+  "start": "./.cursor/start.sh",
+  "terminals": [
+    {
+      "name": "web",
+      "command": "pnpm dev",
+      "description": "GitPress.net platform (Next.js) dev server on http://localhost:3000"
+    }
+  ],
+  "ports": [
+    { "name": "web", "port": 3000 }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Idempotent dependency + local-state setup for the GitPress.net platform.
+# Runs after the repository is checked out. Safe to run repeatedly.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+# --- System dependency: local Postgres (metadata store) --------------------
+# Normally baked into the environment snapshot; installed here as a fallback so
+# the setup is reproducible on a bare base image as well.
+if ! command -v pg_ctlcluster >/dev/null 2>&1; then
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq postgresql postgresql-contrib
+fi
+
+# --- JS/TS dependencies -----------------------------------------------------
+corepack enable >/dev/null 2>&1 || true
+pnpm install --frozen-lockfile
+
+# --- Local platform env file (only created if absent) -----------------------
+env_file="apps/web/.env.local"
+if [ ! -f "$env_file" ]; then
+  cat > "$env_file" <<EOF
+# Auto-generated local dev env. OAuth pairs are blank (login buttons hidden
+# until you fill a pair in — see apps/web/.env.example).
+DATABASE_URL="postgres://gitpress:gitpress@127.0.0.1:5432/gitpress"
+AUTH_SECRET="$(openssl rand -base64 32)"
+AUTH_URL="http://localhost:3000"
+GITPRESS_THEMES_REPO="tap6/gitpress"
+GITPRESS_BUILD_ACTION_REPO="tap6/build-action"
+GITPRESS_SECRET_KEY="$(openssl rand -base64 32)"
+EOF
+fi
+
+# --- Bring Postgres up + apply the Drizzle schema ---------------------------
+sudo pg_ctlcluster 16 main start 2>/dev/null || true
+for _ in $(seq 1 30); do sudo -u postgres pg_isready -q && break; sleep 1; done
+
+sudo -u postgres psql -tc "SELECT 1 FROM pg_roles WHERE rolname='gitpress'" | grep -q 1 \
+  || sudo -u postgres psql -c "CREATE ROLE gitpress LOGIN PASSWORD 'gitpress';"
+sudo -u postgres psql -tc "SELECT 1 FROM pg_database WHERE datname='gitpress'" | grep -q 1 \
+  || sudo -u postgres createdb -O gitpress gitpress
+
+set -a; . "$env_file"; set +a
+pnpm --filter @gitpress/web db:push
+
+echo "GitPress install complete."

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Per-boot reconciliation: ensure local Postgres is up and the schema is in
+# sync, then return so the web dev server (terminals) can connect.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+sudo pg_ctlcluster 16 main start 2>/dev/null || true
+for _ in $(seq 1 30); do sudo -u postgres pg_isready -q && break; sleep 1; done
+
+sudo -u postgres psql -tc "SELECT 1 FROM pg_roles WHERE rolname='gitpress'" | grep -q 1 \
+  || sudo -u postgres psql -c "CREATE ROLE gitpress LOGIN PASSWORD 'gitpress';"
+sudo -u postgres psql -tc "SELECT 1 FROM pg_database WHERE datname='gitpress'" | grep -q 1 \
+  || sudo -u postgres createdb -O gitpress gitpress
+
+if [ -f apps/web/.env.local ]; then
+  set -a; . apps/web/.env.local; set +a
+  pnpm --filter @gitpress/web db:push || true
+fi
+
+echo "Postgres ready for GitPress."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a reproducible Cloud Agent development environment for the GitPress.net monorepo.

- `.cursor/environment.json` — declares the `install`/`start` scripts, a `web` terminal running `pnpm dev`, and exposes port `3000`.
- `.cursor/install.sh` — idempotent bootstrap: installs a local Postgres (fallback if not baked into the base image), runs `pnpm install --frozen-lockfile`, generates `apps/web/.env.local` (with freshly generated `AUTH_SECRET` / `GITPRESS_SECRET_KEY` and a local `DATABASE_URL`) if absent, then brings up Postgres and applies the Drizzle schema (`db:push`).
- `.cursor/start.sh` — per-boot reconciliation: starts Postgres, ensures the `gitpress` role/database exist, and re-syncs the schema.

OAuth provider credentials are intentionally left blank; the platform hides any provider whose credentials are missing, so the app runs immediately and login buttons appear only once real credentials are supplied.

## Why

The repo had no committed environment config, so a fresh Cloud Agent had no Node deps, no database, and no way to run the Next.js platform (`apps/web`), which requires Postgres for Auth.js session/user storage.

## Validation

- `pnpm install` and `pnpm typecheck` pass across all workspace packages.
- Local Postgres 16 provisioned; `drizzle-kit push` created all 7 tables (`user`, `account`, `session`, `verificationToken`, `site`, `github_installation`, `ai_settings`).
- `install.sh` runs cleanly and is idempotent (second run: "No changes detected"); `start.sh` reconciles Postgres and schema.
- `pnpm dev` serves the app on `:3000`; `/` (landing) and `/login` both return HTTP 200 and render correctly.

### Demo

[gitpress_dev_server_demo.mp4](https://cursor.com/agents/bc-8b392bd3-52d3-48e5-8366-a7db50d26759/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgitpress_dev_server_demo.mp4)

Landing page:

[GitPress landing page](https://cursor.com/agents/bc-8b392bd3-52d3-48e5-8366-a7db50d26759/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgitpress_landing_page.webp)

Login page (providers unconfigured, graceful notice):

[GitPress login page](https://cursor.com/agents/bc-8b392bd3-52d3-48e5-8366-a7db50d26759/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgitpress_login_page.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b392bd3-52d3-48e5-8366-a7db50d26759?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b392bd3-52d3-48e5-8366-a7db50d26759&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

