### PR TITLE
分类增加顶栏导航开关

### DIFF
--- a/apps/web/src/app/sites/[siteId]/categories/page.tsx
+++ b/apps/web/src/app/sites/[siteId]/categories/page.tsx
@@ -17,8 +17,9 @@ export default async function CategoriesPage({
     <div className="max-w-3xl">
       <h1 className="text-2xl font-normal text-neutral-800">分类</h1>
       <p className="mt-2 text-sm text-neutral-500">
-        维护一份有序的分类列表,前台会自动据此生成顶部导航和归档页。文章在编辑页选择所属分类,
-        原有的自由标签(标签)不受影响。
+        维护一份有序的分类列表。文章在编辑页选择所属分类,前台会为每个分类生成归档页。
+        「顶栏」开关只控制该分类是否出现在站点顶部导航中,不影响文章归属和归档页;关掉不等于删除。
+        原有的自由标签不受影响。
       </p>
       <div className="mt-5 rounded border border-neutral-200 bg-white shadow-sm">
         <CategoriesForm siteId={site.id} initial={categories} />

--- a/apps/web/src/app/sites/[siteId]/categories/page.tsx
+++ b/apps/web/src/app/sites/[siteId]/categories/page.tsx
@@ -18,7 +18,7 @@ export default async function CategoriesPage({
       <h1 className="text-2xl font-normal text-neutral-800">分类</h1>
       <p className="mt-2 text-sm text-neutral-500">
         维护一份有序的分类列表。文章在编辑页选择所属分类,前台会为每个分类生成归档页。
-        「顶栏」开关只控制该分类是否出现在站点顶部导航中,不影响文章归属和归档页;关掉不等于删除。
+        「顶栏导航」只决定要不要出现在站点菜单里,关掉不等于删除,归档页和文章归属都还在。
         原有的自由标签不受影响。
       </p>
       <div className="mt-5 rounded border border-neutral-200 bg-white shadow-sm">

--- a/apps/web/src/components/CategoriesForm.tsx
+++ b/apps/web/src/components/CategoriesForm.tsx
@@ -3,7 +3,7 @@
 import { useActionState, useState } from "react";
 import { ProgressButton } from "@/components/ProgressButton";
 import { saveCategoriesAction, type SaveCategoriesState } from "@/lib/actions";
-import type { SiteCategory } from "@/lib/content";
+import { isCategoryInNav, type SiteCategory } from "@/lib/content";
 
 interface Row extends SiteCategory {
   /** Client-only key so React can track rows across reorders/deletes. */
@@ -31,7 +31,9 @@ interface Props {
 }
 
 export function CategoriesForm({ siteId, initial }: Props) {
-  const [rows, setRows] = useState<Row[]>(() => initial.map((c) => ({ ...c, key: nextKey() })));
+  const [rows, setRows] = useState<Row[]>(() =>
+    initial.map((c) => ({ ...c, inNav: isCategoryInNav(c), key: nextKey() })),
+  );
   const [state, formAction] = useActionState<SaveCategoriesState, FormData>(
     saveCategoriesAction,
     {},
@@ -45,6 +47,12 @@ export function CategoriesForm({ siteId, initial }: Props) {
 
   function updateSlug(key: string, slug: string) {
     setRows((prev) => prev.map((row) => (row.key === key ? { ...row, slug } : row)));
+  }
+
+  function toggleInNav(key: string) {
+    setRows((prev) =>
+      prev.map((row) => (row.key === key ? { ...row, inNav: !isCategoryInNav(row) } : row)),
+    );
   }
 
   function remove(key: string) {
@@ -63,11 +71,15 @@ export function CategoriesForm({ siteId, initial }: Props) {
   }
 
   function addRow() {
-    setRows((prev) => [...prev, { key: nextKey(), slug: "", label: "" }]);
+    setRows((prev) => [...prev, { key: nextKey(), slug: "", label: "", inNav: true }]);
   }
 
   const categoriesJson = JSON.stringify(
-    rows.map((row) => ({ slug: row.slug || localSlugify(row.label), label: row.label })),
+    rows.map((row) => ({
+      slug: row.slug || localSlugify(row.label),
+      label: row.label,
+      inNav: isCategoryInNav(row),
+    })),
   );
 
   return (
@@ -79,51 +91,85 @@ export function CategoriesForm({ siteId, initial }: Props) {
         <p className="text-neutral-400">还没有分类,添加一个开始规划你的站点栏目吧。</p>
       )}
 
+      {rows.length > 0 && (
+        <div className="hidden items-center gap-2 pr-8 text-xs text-neutral-400 sm:flex">
+          <span className="w-6 shrink-0" />
+          <span className="min-w-[140px] flex-1">名称</span>
+          <span className="w-40">slug</span>
+          <span className="w-[4.5rem] text-center">顶栏</span>
+        </div>
+      )}
+
       <div className="space-y-2">
-        {rows.map((row, index) => (
-          <div key={row.key} className="flex flex-wrap items-center gap-2 sm:flex-nowrap">
-            <div className="flex shrink-0 flex-row sm:flex-col">
+        {rows.map((row, index) => {
+          const inNav = isCategoryInNav(row);
+          return (
+            <div key={row.key} className="flex flex-wrap items-center gap-2 sm:flex-nowrap">
+              <div className="flex shrink-0 flex-row sm:flex-col">
+                <button
+                  type="button"
+                  onClick={() => move(row.key, -1)}
+                  disabled={index === 0}
+                  className="px-1 text-neutral-400 hover:text-neutral-700 disabled:opacity-20"
+                  aria-label="上移"
+                >
+                  ▲
+                </button>
+                <button
+                  type="button"
+                  onClick={() => move(row.key, 1)}
+                  disabled={index === rows.length - 1}
+                  className="px-1 text-neutral-400 hover:text-neutral-700 disabled:opacity-20"
+                  aria-label="下移"
+                >
+                  ▼
+                </button>
+              </div>
+              <input
+                value={row.label}
+                onChange={(e) => updateLabel(row.key, e.target.value)}
+                placeholder="分类名称,例如:技术"
+                className="min-w-[140px] flex-1 rounded border border-neutral-300 px-3 py-2 focus:border-wp-accent focus:outline-none"
+              />
+              <input
+                value={row.slug}
+                onChange={(e) => updateSlug(row.key, e.target.value)}
+                placeholder="slug,自动生成"
+                className="w-full rounded border border-neutral-300 px-3 py-2 font-mono text-xs text-neutral-500 focus:border-wp-accent focus:outline-none sm:w-40"
+              />
+              <div
+                className="flex w-[4.5rem] shrink-0 flex-col items-center gap-0.5"
+                title={inNav ? "显示在站点顶部导航" : "不显示在顶部导航,归档页仍会生成"}
+              >
+                <span className="text-[11px] text-neutral-400 sm:hidden">顶栏</span>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={inNav}
+                  aria-label={`${row.label || "此分类"}显示在顶部导航`}
+                  onClick={() => toggleInNav(row.key)}
+                  className={`relative h-5 w-9 cursor-pointer rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-wp-accent focus-visible:ring-offset-1 ${
+                    inNav ? "bg-wp-accent" : "bg-neutral-300"
+                  }`}
+                >
+                  <span
+                    className={`absolute top-0.5 left-0.5 block h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${
+                      inNav ? "translate-x-4" : "translate-x-0"
+                    }`}
+                  />
+                </button>
+              </div>
               <button
                 type="button"
-                onClick={() => move(row.key, -1)}
-                disabled={index === 0}
-                className="px-1 text-neutral-400 hover:text-neutral-700 disabled:opacity-20"
-                aria-label="上移"
+                onClick={() => remove(row.key)}
+                className="shrink-0 px-2 text-neutral-400 hover:text-red-600"
+                aria-label="删除"
               >
-                ▲
-              </button>
-              <button
-                type="button"
-                onClick={() => move(row.key, 1)}
-                disabled={index === rows.length - 1}
-                className="px-1 text-neutral-400 hover:text-neutral-700 disabled:opacity-20"
-                aria-label="下移"
-              >
-                ▼
+                ✕
               </button>
             </div>
-            <input
-              value={row.label}
-              onChange={(e) => updateLabel(row.key, e.target.value)}
-              placeholder="分类名称,例如:技术"
-              className="min-w-[140px] flex-1 rounded border border-neutral-300 px-3 py-2 focus:border-wp-accent focus:outline-none"
-            />
-            <input
-              value={row.slug}
-              onChange={(e) => updateSlug(row.key, e.target.value)}
-              placeholder="slug,自动生成"
-              className="w-full rounded border border-neutral-300 px-3 py-2 font-mono text-xs text-neutral-500 focus:border-wp-accent focus:outline-none sm:w-40"
-            />
-            <button
-              type="button"
-              onClick={() => remove(row.key)}
-              className="shrink-0 px-2 text-neutral-400 hover:text-red-600"
-              aria-label="删除"
-            >
-              ✕
-            </button>
-          </div>
-        ))}
+          );
+        })}
       </div>
 
       <button

--- a/apps/web/src/components/CategoriesForm.tsx
+++ b/apps/web/src/components/CategoriesForm.tsx
@@ -3,7 +3,7 @@
 import { useActionState, useState } from "react";
 import { ProgressButton } from "@/components/ProgressButton";
 import { saveCategoriesAction, type SaveCategoriesState } from "@/lib/actions";
-import { isCategoryInNav, type SiteCategory } from "@/lib/content";
+import { isCategoryInNav, persistSiteCategory, type SiteCategory } from "@/lib/categories";
 
 interface Row extends SiteCategory {
   /** Client-only key so React can track rows across reorders/deletes. */
@@ -75,119 +75,138 @@ export function CategoriesForm({ siteId, initial }: Props) {
   }
 
   const categoriesJson = JSON.stringify(
-    rows.map((row) => ({
-      slug: row.slug || localSlugify(row.label),
-      label: row.label,
-      inNav: isCategoryInNav(row),
-    })),
+    rows.map((row) =>
+      persistSiteCategory({
+        slug: row.slug || localSlugify(row.label),
+        label: row.label,
+        inNav: isCategoryInNav(row),
+      }),
+    ),
   );
 
   return (
-    <form action={formAction} className="space-y-4 p-5 text-sm">
+    <form action={formAction} className="text-sm">
       <input type="hidden" name="siteId" value={siteId} />
       <input type="hidden" name="categoriesJson" value={categoriesJson} />
 
-      {rows.length === 0 && (
-        <p className="text-neutral-400">还没有分类,添加一个开始规划你的站点栏目吧。</p>
-      )}
-
-      {rows.length > 0 && (
-        <div className="hidden items-center gap-2 pr-8 text-xs text-neutral-400 sm:flex">
-          <span className="w-6 shrink-0" />
-          <span className="min-w-[140px] flex-1">名称</span>
-          <span className="w-40">slug</span>
-          <span className="w-[4.5rem] text-center">顶栏</span>
-        </div>
-      )}
-
-      <div className="space-y-2">
-        {rows.map((row, index) => {
-          const inNav = isCategoryInNav(row);
-          return (
-            <div key={row.key} className="flex flex-wrap items-center gap-2 sm:flex-nowrap">
-              <div className="flex shrink-0 flex-row sm:flex-col">
-                <button
-                  type="button"
-                  onClick={() => move(row.key, -1)}
-                  disabled={index === 0}
-                  className="px-1 text-neutral-400 hover:text-neutral-700 disabled:opacity-20"
-                  aria-label="上移"
-                >
-                  ▲
-                </button>
-                <button
-                  type="button"
-                  onClick={() => move(row.key, 1)}
-                  disabled={index === rows.length - 1}
-                  className="px-1 text-neutral-400 hover:text-neutral-700 disabled:opacity-20"
-                  aria-label="下移"
-                >
-                  ▼
-                </button>
-              </div>
-              <input
-                value={row.label}
-                onChange={(e) => updateLabel(row.key, e.target.value)}
-                placeholder="分类名称,例如:技术"
-                className="min-w-[140px] flex-1 rounded border border-neutral-300 px-3 py-2 focus:border-wp-accent focus:outline-none"
-              />
-              <input
-                value={row.slug}
-                onChange={(e) => updateSlug(row.key, e.target.value)}
-                placeholder="slug,自动生成"
-                className="w-full rounded border border-neutral-300 px-3 py-2 font-mono text-xs text-neutral-500 focus:border-wp-accent focus:outline-none sm:w-40"
-              />
-              <div
-                className="flex w-[4.5rem] shrink-0 flex-col items-center gap-0.5"
-                title={inNav ? "显示在站点顶部导航" : "不显示在顶部导航,归档页仍会生成"}
-              >
-                <span className="text-[11px] text-neutral-400 sm:hidden">顶栏</span>
-                <button
-                  type="button"
-                  role="switch"
-                  aria-checked={inNav}
-                  aria-label={`${row.label || "此分类"}显示在顶部导航`}
-                  onClick={() => toggleInNav(row.key)}
-                  className={`relative h-5 w-9 cursor-pointer rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-wp-accent focus-visible:ring-offset-1 ${
-                    inNav ? "bg-wp-accent" : "bg-neutral-300"
-                  }`}
-                >
-                  <span
-                    className={`absolute top-0.5 left-0.5 block h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${
-                      inNav ? "translate-x-4" : "translate-x-0"
-                    }`}
-                  />
-                </button>
-              </div>
-              <button
-                type="button"
-                onClick={() => remove(row.key)}
-                className="shrink-0 px-2 text-neutral-400 hover:text-red-600"
-                aria-label="删除"
-              >
-                ✕
-              </button>
-            </div>
-          );
-        })}
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-neutral-100 px-4 py-3">
+        <p className="text-xs text-neutral-400">
+          列表顺序就是顶栏顺序。关掉导航的分类仍会生成归档页。
+        </p>
+        <button
+          type="button"
+          onClick={addRow}
+          className="rounded border border-dashed border-neutral-300 px-3 py-1.5 text-neutral-500 hover:border-wp-accent hover:text-wp-accent"
+        >
+          + 添加分类
+        </button>
       </div>
 
-      <button
-        type="button"
-        onClick={addRow}
-        className="rounded border border-dashed border-neutral-300 px-3 py-1.5 text-neutral-500 hover:border-wp-accent hover:text-wp-accent"
-      >
-        + 添加分类
-      </button>
+      <div className="space-y-3 p-4">
+        {rows.length === 0 && (
+          <p className="text-neutral-400">还没有分类,添加一个开始规划你的站点栏目吧。</p>
+        )}
 
-      {state.error && <p className="rounded bg-red-50 p-3 text-red-600">{state.error}</p>}
+        {rows.length > 0 && (
+          <div className="hidden items-center gap-2 text-xs text-neutral-400 sm:flex">
+            <span className="w-6 shrink-0" />
+            <div className="grid min-w-0 flex-1 grid-cols-[minmax(0,1fr)_10rem_7rem] items-center gap-2">
+              <span>名称</span>
+              <span>slug</span>
+              <span className="text-center">顶栏导航</span>
+            </div>
+            <span className="w-8 shrink-0" />
+          </div>
+        )}
+
+        <div className="space-y-2">
+          {rows.map((row, index) => {
+            const inNav = isCategoryInNav(row);
+            return (
+              <div key={row.key} className="flex items-start gap-2 sm:items-center">
+                <div className="flex w-6 shrink-0 flex-row sm:flex-col">
+                  <button
+                    type="button"
+                    onClick={() => move(row.key, -1)}
+                    disabled={index === 0}
+                    className="px-1 text-neutral-400 hover:text-neutral-700 disabled:opacity-20"
+                    aria-label="上移"
+                  >
+                    ▲
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => move(row.key, 1)}
+                    disabled={index === rows.length - 1}
+                    className="px-1 text-neutral-400 hover:text-neutral-700 disabled:opacity-20"
+                    aria-label="下移"
+                  >
+                    ▼
+                  </button>
+                </div>
+                <div className="grid min-w-0 flex-1 grid-cols-1 gap-2 sm:grid-cols-[minmax(0,1fr)_10rem_7rem] sm:items-center">
+                  <input
+                    value={row.label}
+                    onChange={(e) => updateLabel(row.key, e.target.value)}
+                    placeholder="分类名称,例如:技术"
+                    className="min-w-0 w-full rounded border border-neutral-300 px-3 py-2 focus:border-wp-accent focus:outline-none"
+                  />
+                  <input
+                    value={row.slug}
+                    onChange={(e) => updateSlug(row.key, e.target.value)}
+                    placeholder="slug,自动生成"
+                    className="w-full rounded border border-neutral-300 px-3 py-2 font-mono text-xs text-neutral-500 focus:border-wp-accent focus:outline-none"
+                  />
+                  <div
+                    className="flex items-center justify-between gap-2 sm:justify-center"
+                    title={inNav ? "显示在站点顶部导航" : "不显示在顶部导航,归档页仍会生成"}
+                  >
+                    <span className="text-[11px] text-neutral-400 sm:hidden">顶栏导航</span>
+                    <button
+                      type="button"
+                      role="switch"
+                      aria-checked={inNav}
+                      aria-label={`${row.label || "此分类"}显示在顶部导航`}
+                      onClick={() => toggleInNav(row.key)}
+                      className={`relative h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-wp-accent focus-visible:ring-offset-1 ${
+                        inNav ? "bg-wp-accent" : "bg-neutral-300"
+                      }`}
+                    >
+                      <span
+                        className={`absolute top-0.5 left-0.5 block h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${
+                          inNav ? "translate-x-4" : "translate-x-0"
+                        }`}
+                      />
+                    </button>
+                    <span className={`text-[11px] ${inNav ? "text-neutral-500" : "text-neutral-400"}`}>
+                      {inNav ? "显示" : "隐藏"}
+                    </span>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => remove(row.key)}
+                  className="w-8 shrink-0 px-2 pt-2 text-neutral-400 hover:text-red-600 sm:pt-0"
+                  aria-label="删除"
+                >
+                  ✕
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {state.error && (
+        <p className="mx-4 mb-3 rounded bg-red-50 p-3 text-red-600">{state.error}</p>
+      )}
       {state.saved && (
-        <p className="rounded bg-emerald-50 p-3 text-emerald-700">
+        <p className="mx-4 mb-3 rounded bg-emerald-50 p-3 text-emerald-700">
           已保存,站点将在约 1 分钟后更新导航。
         </p>
       )}
 
-      <div>
+      <div className="border-t border-neutral-100 bg-neutral-50 px-4 py-3">
         <ProgressButton
           expectedSeconds={4}
           pendingLabel="保存中"

--- a/apps/web/src/lib/actions.ts
+++ b/apps/web/src/lib/actions.ts
@@ -6,6 +6,7 @@ import { redirect } from "next/navigation";
 import { db } from "@/db";
 import { githubInstallations, sites } from "@/db/schema";
 import { deleteAiConfig, generateDraft, generateSummary, getAiConfig, saveAiConfig } from "./ai";
+import { persistSiteCategory, type SiteCategory } from "./categories";
 import {
   deleteMedia,
   deletePost,
@@ -13,8 +14,6 @@ import {
   saveSiteCategories,
   savePost,
   slugify,
-  isCategoryInNav,
-  type SiteCategory,
   updatePostMeta,
   updateSiteConfig,
   uploadMedia,
@@ -441,8 +440,11 @@ export async function saveCategoriesAction(
       let slug = slugify(String((item as { slug?: unknown })?.slug ?? "") || label);
       while (seen.has(slug)) slug = `${slug}-2`;
       seen.add(slug);
-      const inNav = isCategoryInNav(item as { inNav?: boolean });
-      return { slug, label, inNav };
+      return persistSiteCategory({
+        slug,
+        label,
+        inNav: (item as { inNav?: unknown }).inNav === false ? false : undefined,
+      });
     });
   } catch (error) {
     return { error: error instanceof Error ? error.message : "分类数据格式有误" };

--- a/apps/web/src/lib/actions.ts
+++ b/apps/web/src/lib/actions.ts
@@ -13,6 +13,7 @@ import {
   saveSiteCategories,
   savePost,
   slugify,
+  isCategoryInNav,
   type SiteCategory,
   updatePostMeta,
   updateSiteConfig,
@@ -440,7 +441,8 @@ export async function saveCategoriesAction(
       let slug = slugify(String((item as { slug?: unknown })?.slug ?? "") || label);
       while (seen.has(slug)) slug = `${slug}-2`;
       seen.add(slug);
-      return { slug, label };
+      const inNav = isCategoryInNav(item as { inNav?: boolean });
+      return { slug, label, inNav };
     });
   } catch (error) {
     return { error: error instanceof Error ? error.message : "分类数据格式有误" };

--- a/apps/web/src/lib/categories.ts
+++ b/apps/web/src/lib/categories.ts
@@ -1,0 +1,23 @@
+/** Site-owner-maintained category. Stored on `gitpress.json` → `site.categories`. */
+export interface SiteCategory {
+  slug: string;
+  label: string;
+  /** When false, omit from the generated site's top nav. Missing means true. */
+  inNav?: boolean;
+}
+
+/** Top-nav visibility. Absent `inNav` is treated as true so existing sites keep their menus. */
+export function isCategoryInNav(category: Pick<SiteCategory, "inNav">): boolean {
+  return category.inNav !== false;
+}
+
+/**
+ * Write `inNav` only when it is off. Missing means true, so persisting `true`
+ * would rewrite every existing category on the first save after this field
+ * shipped — a noisy commit and a wasted Actions run.
+ */
+export function persistSiteCategory(category: SiteCategory): SiteCategory {
+  const persisted: SiteCategory = { slug: category.slug, label: category.label };
+  if (category.inNav === false) persisted.inNav = false;
+  return persisted;
+}

--- a/apps/web/src/lib/content.ts
+++ b/apps/web/src/lib/content.ts
@@ -1,7 +1,11 @@
 import matter from "gray-matter";
 import type { Octokit } from "octokit";
+import { persistSiteCategory, type SiteCategory } from "./categories";
 import { deleteFile, getFileText, listDirectory, putFile, commitFiles, splitRepo } from "./github";
 import { sanitizeMediaFileName, uniqueMediaFileName } from "./mediaName";
+
+export type { SiteCategory } from "./categories";
+export { isCategoryInNav, persistSiteCategory } from "./categories";
 
 /** Content operations = commits against the private data repository. */
 
@@ -295,17 +299,6 @@ export async function updateSiteConfig(
 // Categories (site-level, ordered list maintained by the site owner)
 // ---------------------------------------------------------------------------
 
-export interface SiteCategory {
-  slug: string;
-  label: string;
-  /** When false, omit from the generated site's top nav. Missing means true. */
-  inNav?: boolean;
-}
-
-export function isCategoryInNav(category: Pick<SiteCategory, "inNav">): boolean {
-  return category.inNav !== false;
-}
-
 export async function getSiteCategories(
   octokit: Octokit,
   dataRepo: string,
@@ -321,11 +314,7 @@ export async function getSiteCategories(
         typeof (item as SiteCategory).slug === "string" &&
         typeof (item as SiteCategory).label === "string",
     )
-    .map((item) => ({
-      slug: item.slug,
-      label: item.label,
-      inNav: isCategoryInNav(item),
-    }));
+    .map((item) => persistSiteCategory(item));
 }
 
 export async function saveSiteCategories(
@@ -337,7 +326,7 @@ export async function saveSiteCategories(
     octokit,
     dataRepo,
     (config) => {
-      config.site.categories = categories;
+      config.site.categories = categories.map(persistSiteCategory);
     },
     "Update categories",
   );

--- a/apps/web/src/lib/content.ts
+++ b/apps/web/src/lib/content.ts
@@ -298,6 +298,12 @@ export async function updateSiteConfig(
 export interface SiteCategory {
   slug: string;
   label: string;
+  /** When false, omit from the generated site's top nav. Missing means true. */
+  inNav?: boolean;
+}
+
+export function isCategoryInNav(category: Pick<SiteCategory, "inNav">): boolean {
+  return category.inNav !== false;
 }
 
 export async function getSiteCategories(
@@ -315,7 +321,11 @@ export async function getSiteCategories(
         typeof (item as SiteCategory).slug === "string" &&
         typeof (item as SiteCategory).label === "string",
     )
-    .map((item) => ({ slug: item.slug, label: item.label }));
+    .map((item) => ({
+      slug: item.slug,
+      label: item.label,
+      inNav: isCategoryInNav(item),
+    }));
 }
 
 export async function saveSiteCategories(

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -30,7 +30,7 @@ GitPress 生态的共同契约:平台、构建 Action、所有主题(包括 AI �
     "title": "我的博客",
     "categories": [
       { "slug": "tech", "label": "技术" },
-      { "slug": "life", "label": "生活" }
+      { "slug": "notes", "label": "随笔", "inNav": false }
     ],
     "postsPerPage": 10,
     "analyticsSnippet": "<script>/* GA4 / Umami / Plausible / Clarity 等平台给的完整代码,原样插入 </head> 前 */</script>"
@@ -38,7 +38,7 @@ GitPress 生态的共同契约:平台、构建 Action、所有主题(包括 AI �
 }
 ```
 
-- `categories`:站长维护的有序分类列表,主题据此渲染顶部导航与 `/categories/<slug>/` 归档页。每篇文章从这个列表选一个主分类(写入 frontmatter 的 `categories` 数组第 0 项),与自由的 `tags` 并存、互不影响。
+- `categories`:站长维护的有序分类列表。主题为每个分类生成 `/categories/<slug>/` 归档页;顶部导航只包含 `inNav` 不为 `false` 的项(缺省为 `true`,现有站点菜单不变)。每篇文章从这个列表选一个主分类(写入 frontmatter 的 `categories` 数组第 0 项),与自由的 `tags` 并存、互不影响。关掉顶栏不等于删除分类。
 - `postsPerPage`:首页与归档页的分页大小,缺省 10。
 - `analyticsSnippet`:原始 HTML/脚本片段,缺省不注入任何统计代码。
 

--- a/packages/spec/schemas/gitpress.schema.json
+++ b/packages/spec/schemas/gitpress.schema.json
@@ -35,13 +35,18 @@
         "timezone": { "type": "string", "default": "UTC" },
         "categories": {
           "type": "array",
-          "description": "Ordered, site-owner-maintained categories. Themes render these as top nav links plus /categories/<slug>/ archive pages. Distinct from posts' free-form tags — each post picks at most one category from this list.",
+          "description": "Ordered, site-owner-maintained categories. Themes render /categories/<slug>/ archive pages for every entry, and top nav links for those with inNav !== false. Distinct from posts' free-form tags — each post picks at most one category from this list.",
           "items": {
             "type": "object",
             "required": ["slug", "label"],
             "properties": {
               "slug": { "type": "string", "minLength": 1 },
-              "label": { "type": "string", "minLength": 1 }
+              "label": { "type": "string", "minLength": 1 },
+              "inNav": {
+                "type": "boolean",
+                "default": true,
+                "description": "When false, omit this category from the generated site's top navigation. Archive pages and post assignment are unaffected. Missing means true."
+              }
             },
             "additionalProperties": true
           }

--- a/packages/spec/src/index.ts
+++ b/packages/spec/src/index.ts
@@ -35,6 +35,17 @@ export interface SiteCategory {
   slug: string;
   /** Display label, e.g. "Tech". */
   label: string;
+  /**
+   * When false, themes omit this category from the top navigation.
+   * Archive pages (`/categories/<slug>/`) and post assignment are unaffected.
+   * Missing or true means the category appears in the nav. Default true.
+   */
+  inNav?: boolean;
+}
+
+/** Top-nav visibility. Absent `inNav` is treated as true so existing sites keep their current menus. */
+export function isCategoryInNav(category: Pick<SiteCategory, "inNav">): boolean {
+  return category.inNav !== false;
 }
 
 export interface SiteInfo {
@@ -50,10 +61,11 @@ export interface SiteInfo {
   timezone?: string;
   /**
    * Ordered list of categories maintained by the site owner. Themes render
-   * these as top nav links plus `/categories/<slug>/` archive pages. Distinct
-   * from the free-form `tags` on individual posts — every post picks at most
-   * one category from this list (stored as `categories: [slug]` in its
-   * frontmatter), while tags remain unrestricted.
+   * `/categories/<slug>/` archive pages for every entry, and top nav links
+   * for those with `inNav !== false`. Distinct from the free-form `tags` on
+   * individual posts — every post picks at most one category from this list
+   * (stored as `categories: [slug]` in its frontmatter), while tags remain
+   * unrestricted.
    */
   categories?: SiteCategory[];
   /** Posts per page for the homepage and category archives. Default 10. */

--- a/themes/classic/src/layouts/Base.astro
+++ b/themes/classic/src/layouts/Base.astro
@@ -1,6 +1,6 @@
 ---
 import { getCollection } from "astro:content";
-import { gitpress, themeConfig, withBase, postSlug, siteCategories } from "../lib/gitpress";
+import { gitpress, themeConfig, withBase, postSlug, navCategories } from "../lib/gitpress";
 import "../styles/global.css";
 
 interface Props {
@@ -38,7 +38,7 @@ const navPages = (await getCollection("pages")).sort((a, b) =>
       {site.description && <p class="site-tagline">{site.description}</p>}
       <nav class="site-nav">
         <a href={withBase("/")}>Home</a>
-        {siteCategories.map((category) => (
+        {navCategories.map((category) => (
           <a href={withBase(`/categories/${category.slug}/`)}>{category.label}</a>
         ))}
         {navPages.map((page) => <a href={withBase(`/${postSlug(page)}/`)}>{page.data.title}</a>)}

--- a/themes/classic/src/lib/gitpress.ts
+++ b/themes/classic/src/lib/gitpress.ts
@@ -4,6 +4,8 @@ import { getCollection, type CollectionEntry } from "astro:content";
 interface SiteCategory {
   slug: string;
   label: string;
+  /** When false, omit from top nav. Missing means true. */
+  inNav?: boolean;
 }
 
 interface SiteInfo {
@@ -51,8 +53,14 @@ export const themeConfig = {
 export type Post = CollectionEntry<"posts">;
 export type Page = CollectionEntry<"pages">;
 
-/** Ordered, site-owner-maintained categories — drives top nav + archive pages. */
+function isCategoryInNav(category: SiteCategory): boolean {
+  return category.inNav !== false;
+}
+
+/** Ordered, site-owner-maintained categories — drives archive pages. */
 export const siteCategories: SiteCategory[] = gitpress.site.categories ?? [];
+/** Categories shown in the top nav. Absent `inNav` is treated as true. */
+export const navCategories: SiteCategory[] = siteCategories.filter(isCategoryInNav);
 export const postsPerPage: number = gitpress.site.postsPerPage ?? 10;
 
 export function categoryLabel(slug: string): string {

--- a/themes/classic/src/lib/gitpress.ts
+++ b/themes/classic/src/lib/gitpress.ts
@@ -53,14 +53,10 @@ export const themeConfig = {
 export type Post = CollectionEntry<"posts">;
 export type Page = CollectionEntry<"pages">;
 
-function isCategoryInNav(category: SiteCategory): boolean {
-  return category.inNav !== false;
-}
-
 /** Ordered, site-owner-maintained categories — drives archive pages. */
 export const siteCategories: SiteCategory[] = gitpress.site.categories ?? [];
 /** Categories shown in the top nav. Absent `inNav` is treated as true. */
-export const navCategories: SiteCategory[] = siteCategories.filter(isCategoryInNav);
+export const navCategories: SiteCategory[] = siteCategories.filter((category) => category.inNav !== false);
 export const postsPerPage: number = gitpress.site.postsPerPage ?? 10;
 
 export function categoryLabel(slug: string): string {

--- a/themes/ink/src/layouts/Base.astro
+++ b/themes/ink/src/layouts/Base.astro
@@ -1,6 +1,6 @@
 ---
 import { getCollection } from "astro:content";
-import { gitpress, themeConfig, withBase, postSlug, siteCategories } from "../lib/gitpress";
+import { gitpress, themeConfig, withBase, postSlug, navCategories } from "../lib/gitpress";
 import "../styles/global.css";
 
 interface Props {
@@ -38,7 +38,7 @@ const navPages = (await getCollection("pages")).sort((a, b) =>
       {site.description && <p class="site-tagline">{site.description}</p>}
       <nav class="site-nav">
         <a href={withBase("/")}>Home</a>
-        {siteCategories.map((category) => (
+        {navCategories.map((category) => (
           <a href={withBase(`/categories/${category.slug}/`)}>{category.label}</a>
         ))}
         {navPages.map((page) => <a href={withBase(`/${postSlug(page)}/`)}>{page.data.title}</a>)}

--- a/themes/ink/src/lib/gitpress.ts
+++ b/themes/ink/src/lib/gitpress.ts
@@ -4,6 +4,8 @@ import { getCollection, type CollectionEntry } from "astro:content";
 interface SiteCategory {
   slug: string;
   label: string;
+  /** When false, omit from top nav. Missing means true. */
+  inNav?: boolean;
 }
 
 interface SiteInfo {
@@ -51,8 +53,14 @@ export const themeConfig = {
 export type Post = CollectionEntry<"posts">;
 export type Page = CollectionEntry<"pages">;
 
-/** Ordered, site-owner-maintained categories — drives top nav + archive pages. */
+function isCategoryInNav(category: SiteCategory): boolean {
+  return category.inNav !== false;
+}
+
+/** Ordered, site-owner-maintained categories — drives archive pages. */
 export const siteCategories: SiteCategory[] = gitpress.site.categories ?? [];
+/** Categories shown in the top nav. Absent `inNav` is treated as true. */
+export const navCategories: SiteCategory[] = siteCategories.filter(isCategoryInNav);
 export const postsPerPage: number = gitpress.site.postsPerPage ?? 10;
 
 export function categoryLabel(slug: string): string {

--- a/themes/ink/src/lib/gitpress.ts
+++ b/themes/ink/src/lib/gitpress.ts
@@ -53,14 +53,10 @@ export const themeConfig = {
 export type Post = CollectionEntry<"posts">;
 export type Page = CollectionEntry<"pages">;
 
-function isCategoryInNav(category: SiteCategory): boolean {
-  return category.inNav !== false;
-}
-
 /** Ordered, site-owner-maintained categories — drives archive pages. */
 export const siteCategories: SiteCategory[] = gitpress.site.categories ?? [];
 /** Categories shown in the top nav. Absent `inNav` is treated as true. */
-export const navCategories: SiteCategory[] = siteCategories.filter(isCategoryInNav);
+export const navCategories: SiteCategory[] = siteCategories.filter((category) => category.inNav !== false);
 export const postsPerPage: number = gitpress.site.postsPerPage ?? 10;
 
 export function categoryLabel(slug: string): string {

--- a/themes/minimal/src/layouts/Base.astro
+++ b/themes/minimal/src/layouts/Base.astro
@@ -1,6 +1,6 @@
 ---
 import { getCollection } from "astro:content";
-import { gitpress, themeConfig, withBase, postSlug, siteCategories } from "../lib/gitpress";
+import { gitpress, themeConfig, withBase, postSlug, navCategories } from "../lib/gitpress";
 import "../styles/global.css";
 
 interface Props {
@@ -36,7 +36,7 @@ const navPages = (await getCollection("pages")).sort((a, b) =>
     <header class="site-header">
       <p class="site-title"><a href={withBase("/")}>{site.title}</a></p>
       <nav class="site-nav">
-        {siteCategories.map((category) => (
+        {navCategories.map((category) => (
           <a href={withBase(`/categories/${category.slug}/`)}>{category.label}</a>
         ))}
         {navPages.map((page) => <a href={withBase(`/${postSlug(page)}/`)}>{page.data.title}</a>)}

--- a/themes/minimal/src/lib/gitpress.ts
+++ b/themes/minimal/src/lib/gitpress.ts
@@ -4,6 +4,8 @@ import { getCollection, type CollectionEntry } from "astro:content";
 interface SiteCategory {
   slug: string;
   label: string;
+  /** When false, omit from top nav. Missing means true. */
+  inNav?: boolean;
 }
 
 interface SiteInfo {
@@ -51,8 +53,14 @@ export const themeConfig = {
 export type Post = CollectionEntry<"posts">;
 export type Page = CollectionEntry<"pages">;
 
-/** Ordered, site-owner-maintained categories — drives top nav + archive pages. */
+function isCategoryInNav(category: SiteCategory): boolean {
+  return category.inNav !== false;
+}
+
+/** Ordered, site-owner-maintained categories — drives archive pages. */
 export const siteCategories: SiteCategory[] = gitpress.site.categories ?? [];
+/** Categories shown in the top nav. Absent `inNav` is treated as true. */
+export const navCategories: SiteCategory[] = siteCategories.filter(isCategoryInNav);
 export const postsPerPage: number = gitpress.site.postsPerPage ?? 10;
 
 export function categoryLabel(slug: string): string {

--- a/themes/minimal/src/lib/gitpress.ts
+++ b/themes/minimal/src/lib/gitpress.ts
@@ -53,14 +53,10 @@ export const themeConfig = {
 export type Post = CollectionEntry<"posts">;
 export type Page = CollectionEntry<"pages">;
 
-function isCategoryInNav(category: SiteCategory): boolean {
-  return category.inNav !== false;
-}
-
 /** Ordered, site-owner-maintained categories — drives archive pages. */
 export const siteCategories: SiteCategory[] = gitpress.site.categories ?? [];
 /** Categories shown in the top nav. Absent `inNav` is treated as true. */
-export const navCategories: SiteCategory[] = siteCategories.filter(isCategoryInNav);
+export const navCategories: SiteCategory[] = siteCategories.filter((category) => category.inNav !== false);
 export const postsPerPage: number = gitpress.site.postsPerPage ?? 10;
 
 export function categoryLabel(slug: string): string {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
分类列表同时承担「文章归类」和「顶部导航」两件事。分类一多，顶栏会被撑满；想从导航拿掉某个栏目，以前只能删分类，归档页和文章归属也会一起没。

这次把展示层拆开：每个分类增加可选字段 `inNav`（缺省 `true`），后台用开关控制是否出现在生成站点的顶部导航。关掉不等于删除，不影响文章归属、后台筛选、以及 `/categories/<slug>/` 归档页。

## 改动

- 规范：`site.categories[].inNav`，缺字段视为显示，现有站点菜单不变
- 后台分类表单：每行一个「顶栏」开关，读写写入 `gitpress.json`
- classic / ink / minimal：顶栏改用 `navCategories`（`inNav !== false`），归档页仍用完整分类列表

站点保存分类后会触发重建；内置主题需带上本次主题改动后，关闭开关才会真正从顶栏消失。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b8c2b85-777a-44a9-a01e-8fba7a500b74?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b8c2b85-777a-44a9-a01e-8fba7a500b74&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

